### PR TITLE
Handling returns in search

### DIFF
--- a/alembic-jekyll-theme.gemspec
+++ b/alembic-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "alembic-jekyll-theme"
-  spec.version       = "2.2.2"
+  spec.version       = "2.2.1"
   spec.authors       = ["David Darnes"]
   spec.email         = ["me@daviddarnes.com"]
 

--- a/assets/search.json
+++ b/assets/search.json
@@ -12,7 +12,7 @@ sitemap: false
       {
         "title": {{ doc.title | jsonify }},
         "excerpt": {{ doc.excerpt | markdownify | strip_html | jsonify }},
-        "content": {{ doc.content | markdownify | strip_html | jsonify | replace:'\n',' ' | replace:'   ',' ' | replace:'  ',' ' }},
+        "content": {{ doc.content | markdownify | strip_html | jsonify }},
         "url": {{ site.baseurl | append: doc.url | jsonify }}
       },
     {% endfor %}
@@ -22,7 +22,7 @@ sitemap: false
   {
     "title": {{ page.title | jsonify }},
     "excerpt": {{ page.excerpt | markdownify | strip_html | jsonify }},
-    "content": {{ page.content | markdownify | strip_html | jsonify | replace:'\n',' ' | replace:'   ',' ' | replace:'  ',' ' }},
+    "content": {{ page.content | markdownify | strip_html | jsonify }},
     "url": {{ site.baseurl | append: page.url | jsonify }}
   }{% unless forloop.last %},{% endunless %}
   {% endfor %}


### PR DESCRIPTION
## Summary
It seems when `\n` is added to the content of a page or post is causes the search functionality to break. So either the javascript isn't handling returns correctly, or we shouldn't be stripping them in the json data. 

In this PR I've gone for the latter, which seems to be working. Leaving the returns how they are seems to be fine for the search.

Issue raised in #61 