### PR TITLE
Category listing excerpt bug

### DIFF
--- a/_includes/post-categories.html
+++ b/_includes/post-categories.html
@@ -9,7 +9,7 @@
 				 	<article class="article  article--post  typeset">
 					 	<h3><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a></h3>
 						{% include post-meta.html %}
-						{{ page.excerpt | markdownify | truncatewords: 60 }}
+						{{ page.excerpt | truncatewords: 60 | markdownify }}
 				 	</article>
 			 </li>
 		 {% endfor %}


### PR DESCRIPTION
On the category list page, if a post excerpt has a piece of html crossing over the truncated 60 word threshold it'll cut off the parts of the markup.

Swapping the filters fixes this, however it cuts off markdown instead. Not idea, but better than it's current state