### PR TITLE
Add nav toggle button to default nav

### DIFF
--- a/_includes/nav-header.html
+++ b/_includes/nav-header.html
@@ -1,8 +1,5 @@
 {% if site.navigation_header %}
 <nav class="nav  nav--header">
-  <button class="button  button--nav" aria-label="Nav toggle">
-    {% include icon.html id="nav" %}
-  </button>
   <ul class="list  list--nav">
     {% for item in site.navigation_header %}
 
@@ -21,7 +18,20 @@
 {% else %}
   {% include nav-default.html %}
 {% endif %}
+
+<template id="buttontoggle">
+  <button class="button  button--nav" aria-label="Nav toggle">
+    {% include icon.html id="nav" %}
+  </button>
+</template>
+
 <script type="text/javascript">
+
+const nav = document.querySelector('.nav')
+const buttonTemplate = document.querySelector('#buttontoggle')
+const button = document.importNode(buttonTemplate.content, true)
+nav.appendChild(button)
+
 const applyToggle = (list, button, breakpoint) => {
   const navList = document.querySelector(list)
   if (document.body.clientWidth < breakpoint) {
@@ -40,4 +50,5 @@ const applyToggle = (list, button, breakpoint) => {
 }
 
 applyToggle('.list--nav', '.button', 640)
+
 </script>

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -48,6 +48,12 @@ body {
   }
 }
 
+.header .nav {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-end;
+}
+
 .feature {
   padding-bottom: .4rem;
   margin-bottom: 1.6rem;


### PR DESCRIPTION
If a theme user hasn't set a `navigation_header` then the default navigation will be used in the header, but the default navigation was missing the button toggle in its markup. This PR applies the nav button toggle using javascript which adds it to any navigation shown in the header.