### PR TITLE
replace unicode characters

### DIFF
--- a/_sass/sassline-base/_mixins.scss
+++ b/_sass/sassline-base/_mixins.scss
@@ -229,7 +229,7 @@ $max-widths: map-values($maxwidths);
   // Check if value exists in scale.
   $in-scale: in-modular-scale(scale-0, $fontsize);
 
-  // Set the line-height (if it isn’t set at 0).
+  // Set the line-height (if it isn't set at 0).
   @if $lineheight != 0 {
     line-height: #{$lineheight}rem;
   }

--- a/_sass/sassline-base/_variables.scss
+++ b/_sass/sassline-base/_variables.scss
@@ -24,7 +24,7 @@ $rootsizes: (
 ) !default;
 
 // Set the optimum line-length for your text (based on typeface).
-// Aim for 75–100 characters a line when possible, at smaller sizes type size is more important.
+// Aim for 75-100 characters a line when possible, at smaller sizes type size is more important.
 // ! Make sure to have as many widths as breakpoints above.
 // Note: this was 'maxwidths' in previous versions.
 $measures: (


### PR DESCRIPTION
I was getting this

```
LANG=C bundle exec jekyll b _site
Configuration file: /home/stan/src/site/_config.yml
            Source: /home/stan/src/site
       Destination: /home/stan/src/site/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
  Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/styles.scss':
                    Invalid US-ASCII character "\xE2" on line 27
jekyll 3.6.2 | Error:  Invalid US-ASCII character "\xE2" on line 27
```

This commit changes the two non ascii characters as there are simple replacements.  Another fix would be to put @charset "UTF-8"; at the top of the two files (it seems like they need to be in the relevant file rather than the alembic.scss file, perhaps could be removed from there).
