### PR TITLE
Fix: Service Worker generation

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,4 +1,5 @@
 ---
+permalink: "manifest.json"
 ---
 {
   "lang": "{{ site.lang | default: "en-US" }}",

--- a/assets/scripts/sw.js
+++ b/assets/scripts/sw.js
@@ -1,4 +1,5 @@
 ---
+permalink: "/sw.js"
 ---
 const version = '{{ site.time | date: '%Y%m%d%H%M%S' }}';
 const cacheName = `static::${version}`;


### PR DESCRIPTION
Move manifest and service worker to subdirectory but use the permalink front matter to place it at the root of the site.