### PR TITLE
Feature: Add Google Analytics - #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ There are a number of optional settings for you to configure. Use the example [`
 
 You'll need to change the `description`, `title` and `url` to match with the project. You'll also need to replace the `/assets/logo.svg` and `/assets/default-social-image.png` with the project logo and default social image. Setting the site language can be done with `lang`, the theme will default to `en-US`. The `email` needs to be changed to the email you want to receive contact form enquires with. The `disqus` value can be changed to your project username on [Disqus](https://disqus.com), remove this from the `/_config.yml` file if you don't want comments enabled. Look for the `Site settings` comment within the `/_config.yml` file. The `repo` setting is optional, for now, and can be removed entirely, if you wish.
 
+Google Analytics can be enabled via the site configuration too. Add your tracking ID to the `/_config.yml` file in the following method: `google_analytics: 'UA-XXXXXXXX-1'`
+
 By default the built in Service Worker is enabled, and will work on a 'network first' method. That is, if there is no internet connection then the content the Service Worker has cached will be used until the connection comes back. It will always look for a live version of the code first. To disable the Service Worker set an option called `serviceWorker` to false in the `/_config.yml`.
 
 ### Site navigation

--- a/_config.yml
+++ b/_config.yml
@@ -82,6 +82,7 @@ repo: "https://github.com/daviddarnes/alembic"
 email: "me@daviddarnes.com"
 # disqus: "alembic-1" # Blog post comments, uncomment the option and set the site ID from your Disqus account
 avatarurl: "https://www.gravatar.com/avatar/6c0377abcf4da91cdd35dea4554b2a4c" # Uses avatars for favicons to get multple sites, eg Gravatar, Twitter, GitHub
+# google_analytics: ''
 
 # 8. Site navigation
 navigation_header:

--- a/_includes/site-analytics.html
+++ b/_includes/site-analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.googleanalytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.googleanalytics }}');
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,9 +23,11 @@
 		<link rel="manifest" href="{{ "/manifest.json" | relative_url }}">
 		<meta name="theme-color" content="{{ site.manifest.theme_color | default: '#242e2b' }}"/>
 
-    <link rel="stylesheet" href="{{ "/assets/styles.css" | relative_url }}">
+		<link rel="stylesheet" href="{{ "/assets/styles.css" | relative_url }}">
 
 		{% if site.avatarurl %}{% include site-favicons.html %}{% endif %}
+
+		{% if site.google_analytics %}{% include site-analytics.html %}{% endif %}
 	</head>
 	<body class="layout-{{ page.layout }}{% if page.title %}  {{ page.title | slugify }}{% endif %}">
 		{% include site-icons.svg %}


### PR DESCRIPTION
## Summary
This addition has the ability to enable Google Analytics. The script is contained in a single partial, and is enabled when the user adds their "UA" tracking ID to the configuration file (`_config.yml`) for example:
```
google_analytics: 'UA-XXXXXXXX-1'
```

Addresses #84 