### PR TITLE
Feature: Optionally inline CSS - #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Configuration](#configuration)
   - [Gem dependency settings](#gem-dependency-settings)
   - [Site settings](#site-settings)
+  - [Site performance settings](#site-performance-settings)
   - [Site navigation](#site-navigation)
 - [Using includes](#using-includes)
 - [Page layouts](#page-layouts)
@@ -109,7 +110,15 @@ There are a number of optional settings for you to configure. Use the example [`
 
 You'll need to change the `description`, `title` and `url` to match with the project. You'll also need to replace the `/assets/logo.svg` and `/assets/default-social-image.png` with the project logo and default social image. Setting the site language can be done with `lang`, the theme will default to `en-US`. The `email` needs to be changed to the email you want to receive contact form enquires with. The `disqus` value can be changed to your project username on [Disqus](https://disqus.com), remove this from the `/_config.yml` file if you don't want comments enabled. Look for the `Site settings` comment within the `/_config.yml` file. The `repo` setting is optional, for now, and can be removed entirely, if you wish.
 
+### Site performance settings
+
+Alembic comes with a couple of options to enhance the speed and overall performance of the site you build upon it.
+
 By default the built in Service Worker is enabled, and will work on a 'network first' method. That is, if there is no internet connection then the content the Service Worker has cached will be used until the connection comes back. It will always look for a live version of the code first. To disable the Service Worker set an option called `serviceWorker` to false in the `/_config.yml`.
+
+Another option to speed up Alembic is to enable inline CSS, which is off by default. You can enable this by setting `css_inline: true` inside your `/_config.yml` file.
+
+Please note that these options aren't a "silver bullet" for making your site faster, make sure to audit and debug your site to get the best performance for your situation.
 
 ### Site navigation
 

--- a/_config.yml
+++ b/_config.yml
@@ -82,6 +82,7 @@ repo: "https://github.com/daviddarnes/alembic"
 email: "me@daviddarnes.com"
 # disqus: "alembic-1" # Blog post comments, uncomment the option and set the site ID from your Disqus account
 avatarurl: "https://www.gravatar.com/avatar/6c0377abcf4da91cdd35dea4554b2a4c" # Uses avatars for favicons to get multple sites, eg Gravatar, Twitter, GitHub
+css_inline: true # Will insert all styles into a single <style> block in the <head> element and remove the style <link> reference
 
 # 8. Site navigation
 navigation_header:

--- a/_includes/site-styles.html
+++ b/_includes/site-styles.html
@@ -1,0 +1,3 @@
+{% for item in site.pages %}{% if item.styles == true %}
+<style>{{ item.content | scssify }}</style>
+{% endif %}{% endfor %}

--- a/_includes/site-styles.html
+++ b/_includes/site-styles.html
@@ -1,3 +1,3 @@
 {% for item in site.pages %}{% if item.styles == true %}
-<style>{{ item.content | scssify }}</style>
+<style>{{ item.content | scssify | strip_newlines }}</style>
 {% endif %}{% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,9 +23,14 @@
 		<link rel="manifest" href="{{ "/manifest.json" | relative_url }}">
 		<meta name="theme-color" content="{{ site.manifest.theme_color | default: '#242e2b' }}"/>
 
-    <link rel="stylesheet" href="{{ "/assets/styles.css" | relative_url }}">
+    {% if site.css_inline == true %}
+      {% include site-styles.html %}
+    {% else %}
+		  <link rel="stylesheet" href="{{ "/assets/styles.css" | relative_url }}">
+    {% endif %}
 
 		{% if site.avatarurl %}{% include site-favicons.html %}{% endif %}
+
 	</head>
 	<body class="layout-{{ page.layout }}{% if page.title %}  {{ page.title | slugify }}{% endif %}">
 		{% include site-icons.svg %}

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -1,5 +1,6 @@
 ---
 title: false
+styles: true
 ---
 
 @import "alembic";


### PR DESCRIPTION
## Summary
This addition has the ability to inline CSS as a single `<style>` block in the `<head>` element. This comes with speed performance perks (depending on the size of your CSS). This can be enabled in the `/_config.yml` with the following option:

``` yml
css_inline: true
```

Addresses #87