### PR TITLE
Fix: Rename serviceWorker to service_worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ There are a number of optional settings for you to configure. Use the example [`
 
 You'll need to change the `description`, `title` and `url` to match with the project. You'll also need to replace the `/assets/logo.svg` and `/assets/default-social-image.png` with the project logo and default social image. Setting the site language can be done with `lang`, the theme will default to `en-US`. The `email` needs to be changed to the email you want to receive contact form enquires with. The `disqus` value can be changed to your project username on [Disqus](https://disqus.com), remove this from the `/_config.yml` file if you don't want comments enabled. Look for the `Site settings` comment within the `/_config.yml` file. The `repo` setting is optional, for now, and can be removed entirely, if you wish.
 
-By default the built in Service Worker is enabled, and will work on a 'network first' method. That is, if there is no internet connection then the content the Service Worker has cached will be used until the connection comes back. It will always look for a live version of the code first. To disable the Service Worker set an option called `serviceWorker` to false in the `/_config.yml`.
+By default the built in Service Worker is enabled, and will work on a 'network first' method. That is, if there is no internet connection then the content the Service Worker has cached will be used until the connection comes back. It will always look for a live version of the code first. To disable the Service Worker set an option called `service_worker` to false in the `/_config.yml`.
 
 ### Site navigation
 

--- a/_config.yml
+++ b/_config.yml
@@ -82,6 +82,7 @@ repo: "https://github.com/daviddarnes/alembic"
 email: "me@daviddarnes.com"
 # disqus: "alembic-1" # Blog post comments, uncomment the option and set the site ID from your Disqus account
 avatarurl: "https://www.gravatar.com/avatar/6c0377abcf4da91cdd35dea4554b2a4c" # Uses avatars for favicons to get multple sites, eg Gravatar, Twitter, GitHub
+# service_worker: false # Will turn off the service worker if set to false
 
 # 8. Site navigation
 navigation_header:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,6 @@
 
 		{{ content }}
 
-		{% if site.serviceWorker != false %}{% include site-sw.html %}{% endif %}
+		{% if site.service_worker != false %}{% include site-sw.html %}{% endif %}
 	</body>
 </html>


### PR DESCRIPTION
## Summary

This isn't really a fix but more of a consistency correction. All keys in the config file are underscore separated (`like_this`), but for some reason I set the service worker as camel case. This pull request brings it back inline, but will cause breaking changes to people using `serviceWorker`. Thankfully it's an enhancement and won't stop the site being used when the site user is online.