### PR TITLE
Fix: Change pagination text #94

### DIFF
--- a/_includes/post-pagination.html
+++ b/_includes/post-pagination.html
@@ -1,17 +1,17 @@
 <nav class="nav  nav--paginator">
 
   {% if paginator.previous_page %}
-    <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}" class="pagination  pagination--previous">&larr; Previous</a>
+    <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}" class="pagination  pagination--previous">&larr; Newer</a>
   {% else %}
-    <span class="pagination  pagination--previous">&larr; Previous</span>
+    <span class="pagination  pagination--previous">&larr; Newer</span>
   {% endif %}
 
   <span class="pagination  pagination--counter">Page: {{ paginator.page }} of {{ paginator.total_pages }}</span>
 
   {% if paginator.next_page %}
-    <a href="{{ site.baseurl }}{{ paginator.next_page_path }}" class="pagination  pagination--next">Next &rarr;</a>
+    <a href="{{ site.baseurl }}{{ paginator.next_page_path }}" class="pagination  pagination--next">Older &rarr;</a>
   {% else %}
-    <span class="pagination  pagination--next">Next &rarr;</span>
+    <span class="pagination  pagination--next">Older &rarr;</span>
   {% endif %}
 
 </nav>


### PR DESCRIPTION
## Summary
Fix for #94: Fixes pagination text so it's labelled as "Newer" and "Older", better representation of what they do / where they go.