### PR TITLE
Fix: Correct analytics site config reference #92

### DIFF
--- a/_includes/site-analytics.html
+++ b/_includes/site-analytics.html
@@ -1,9 +1,9 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.googleanalytics }}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '{{ site.googleanalytics }}');
+  gtag('config', '{{ site.google_analytics }}');
 </script>


### PR DESCRIPTION
## Summary
Fix for #92: The google analytics html include was referencing an incorrect config key. This should fix it