### PR TITLE
[feature] Add feature to include additional JS to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Google Analytics can be enabled via the site configuration too. Add your trackin
 Date format can be customised in the `/_config.yml` with the option `date_format` (please refer to Liquid date filters documentation for learning about formatting possibilities):
 `date_format: "%-d %B %Y" # NOTE: only placeholder formatting is supported (do not try to use ordinal dates introduced in Jekyll 3.8)`
 
-Additional Javascript files can be included in header or body by adding `include_before_start_js` or `include_before_end_js` in `/_config.yml` file respectively.
+Additional customizations can be included in header or body using `site-before-start.html` or `site-before-start.html` files. This files are included right before HTML body starts and before it ends respectively.
 
 ### Site performance settings
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Google Analytics can be enabled via the site configuration too. Add your trackin
 Date format can be customised in the `/_config.yml` with the option `date_format` (please refer to Liquid date filters documentation for learning about formatting possibilities):
 `date_format: "%-d %B %Y" # NOTE: only placeholder formatting is supported (do not try to use ordinal dates introduced in Jekyll 3.8)`
 
+Additional Javascript files can be included in header or body by adding `include_before_start_js` or `include_before_end_js` in `/_config.yml` file respectively.
+
 ### Site performance settings
 
 Alembic comes with a couple of options to enhance the speed and overall performance of the site you build upon it.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Google Analytics can be enabled via the site configuration too. Add your trackin
 Date format can be customised in the `/_config.yml` with the option `date_format` (please refer to Liquid date filters documentation for learning about formatting possibilities):
 `date_format: "%-d %B %Y" # NOTE: only placeholder formatting is supported (do not try to use ordinal dates introduced in Jekyll 3.8)`
 
-Additional customizations can be included in header or body using `site-before-start.html` or `site-before-start.html` files. This files are included right before HTML body starts and before it ends respectively.
+Additional customizations can be included in header or body using `site-before-start.html` or `site-before-end.html` files. `site-before-start.html` is included just before the closing `</head>` tag and `site-before-end.html` is included just before the closing `</body>` tag.
 
 ### Site performance settings
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ Google Analytics can be enabled via the site configuration too. Add your trackin
 Date format can be customised in the `/_config.yml` with the option `date_format` (please refer to Liquid date filters documentation for learning about formatting possibilities):
 `date_format: "%-d %B %Y" # NOTE: only placeholder formatting is supported (do not try to use ordinal dates introduced in Jekyll 3.8)`
 
-Additional customizations can be included in header or body using `site-before-start.html` or `site-before-end.html` files. `site-before-start.html` is included just before the closing `</head>` tag and `site-before-end.html` is included just before the closing `</body>` tag.
-
 ### Site performance settings
 
 Alembic comes with a couple of options to enhance the speed and overall performance of the site you build upon it.
@@ -245,6 +243,11 @@ Adds a search form to the page.
 Example usage: `{% include site-search.html %}`
 
 This include has no options. This include will add a block of javascript to the page and javascript reference in order for the search field to work correctly.
+
+### `site-before-start.html` & `site-before-end.html`
+Optional html includes for adding scripts, css, js or any embed code you wish to add to every page without the need to overwrite the entire `default.html` template.
+
+**Example usage:** These are different to other includes as they are designed to be overwritten. If you create a `site-before-start.html` file in the `_includes/` the contents of the file will be included just before the closing `</head>` tag. If you create a `site-before-end.html` file the contents of the file will be included just before the closing `</body>` tag.
 
 ## Page layouts
 

--- a/_config.yml
+++ b/_config.yml
@@ -88,13 +88,6 @@ avatarurl: "https://www.gravatar.com/avatar/6c0377abcf4da91cdd35dea4554b2a4c" # 
 # service_worker: false # Will turn off the service worker if set to false
 css_inline: true # Will insert all styles into a single <style> block in the <head> element and remove the style <link> reference
 
-# Include additional javascript files in header and body, scripts must be in a relative path to the site
-# include_before_start_js:
-#  - /assets/scripts/my-awesome-header.js
-# 
-# include_before_end_js:
-#  - /assets/scripts/my-awesome-footer.js
-
 # 8. Site navigation
 navigation_header:
   Home: /

--- a/_config.yml
+++ b/_config.yml
@@ -88,6 +88,13 @@ avatarurl: "https://www.gravatar.com/avatar/6c0377abcf4da91cdd35dea4554b2a4c" # 
 # service_worker: false # Will turn off the service worker if set to false
 css_inline: true # Will insert all styles into a single <style> block in the <head> element and remove the style <link> reference
 
+# Include additional javascript files in header and body, scripts must be in a relative path to the site
+# include_before_start_js:
+#  - /assets/scripts/my-awesome-header.js
+# 
+# include_before_end_js:
+#  - /assets/scripts/my-awesome-footer.js
+
 # 8. Site navigation
 navigation_header:
   Home: /

--- a/_includes/site-before-end.html
+++ b/_includes/site-before-end.html
@@ -1,0 +1,1 @@
+<!-- Overwrite this file with code you want before the closing </body> tag -->

--- a/_includes/site-before-end.html
+++ b/_includes/site-before-end.html
@@ -1,0 +1,3 @@
+{% for script in site.include_before_end_js %}
+  <script async src="{{ script | relative_url }}"></script>
+{% endfor %}

--- a/_includes/site-before-end.html
+++ b/_includes/site-before-end.html
@@ -1,3 +1,0 @@
-{% for script in site.include_before_end_js %}
-  <script async src="{{ script | relative_url }}"></script>
-{% endfor %}

--- a/_includes/site-before-start.html
+++ b/_includes/site-before-start.html
@@ -1,0 +1,1 @@
+<!-- Overwrite this file with code you want before the closing </head> tag -->

--- a/_includes/site-before-start.html
+++ b/_includes/site-before-start.html
@@ -1,0 +1,3 @@
+{% for script in site.include_before_start_js %}
+  <script async src="{{ script | relative_url }}"></script>
+{% endfor %}

--- a/_includes/site-before-start.html
+++ b/_includes/site-before-start.html
@@ -1,3 +1,0 @@
-{% for script in site.include_before_start_js %}
-  <script async src="{{ script | relative_url }}"></script>
-{% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
 
     {% if site.google_analytics %}{% include site-analytics.html %}{% endif %}
 
-    {% if site.include_before_start_js %}{% include site-before-start.html %}{% endif %}
+    {% include site-before-start.html %}
   </head>
 
   <body class="layout-{{ page.layout }}{% if page.title %}  {{ page.title | slugify }}{% endif %}">
@@ -44,7 +44,7 @@
 
     {% if site.service_worker != false %}{% include site-sw.html %}{% endif %}
 
-    {% if site.include_before_end_js %}{% include site-before-end.html %}{% endif %}
+    {% include site-before-end.html %}
   </body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,8 @@
     {% if site.avatarurl %}{% include site-favicons.html %}{% endif %}
 
     {% if site.google_analytics %}{% include site-analytics.html %}{% endif %}
+
+    {% if site.include_before_start_js %}{% include site-before-start.html %}{% endif %}
   </head>
 
   <body class="layout-{{ page.layout }}{% if page.title %}  {{ page.title | slugify }}{% endif %}">
@@ -41,6 +43,8 @@
     {{ content }}
 
     {% if site.service_worker != false %}{% include site-sw.html %}{% endif %}
+
+    {% if site.include_before_end_js %}{% include site-before-end.html %}{% endif %}
   </body>
 
 </html>


### PR DESCRIPTION
Fixes #111 

This feature adds possibility to include additional Javascript files to the header using `include_header_js` parameter in `/_config.yml`.

`include_header_js` is an array of relative javascript paths to include.
eg:

```
include_header_js:
  - my-awesome.js
  - my-second-awesome.js
