### PR TITLE
[Fix]: Prevent nav being hidden when upscaling browser size

### DIFF
--- a/_includes/nav-header.html
+++ b/_includes/nav-header.html
@@ -14,33 +14,34 @@
       </li>
     {% endfor %}
   </ul>
+  <button class="button  button--nav" aria-label="Menu toggle">
+    {% include icon.html id="nav" title="Menu" %}
+  </button>
 </nav>
 {% else %}
   {% include nav-default.html %}
 {% endif %}
 
-<template id="buttontoggle">
-  <button class="button  button--nav" aria-label="Menu toggle">
-    {% include icon.html id="nav" title="Menu" %}
-  </button>
-</template>
-
 <script type="text/javascript">
-  // Append button to nav
-  const buttonTemplate = document.querySelector('#buttontoggle')
-  document.querySelector('.nav')
-    .appendChild(document.importNode(buttonTemplate.content, true))
+  // Get list and button
+  const navList = document.querySelector('.header .list--nav')
+  const button  = document.querySelector('.header .button--nav')
 
-  // Get initial height of nav list
-  const navList = document.querySelector('.list--nav')
-  const navHeight = navList.clientHeight
-
-  // Initially collapse nav
+  // Hide nav and apply toggle
   const collapseNav = () => {
     if (document.body.clientWidth < 640) {
-      navList.style.maxHeight = '0px'
+      navList.style.setProperty('--listHeight', `-${navList.offsetHeight}px`)
     } else {
       navList.removeAttribute('style')
+    }
+
+    button.onclick = () => {
+      navList.style.setProperty('transition', `margin .1s`)
+      if (navList.style.getPropertyValue('--listHeight')) {
+        navList.style.removeProperty('--listHeight')
+      } else {
+        navList.style.setProperty('--listHeight', `-${navList.offsetHeight}px`)
+      }
     }
   }
 
@@ -50,14 +51,4 @@
   window.addEventListener('resize', () => {
     collapseNav()
   })
-
-  // Apply toggle on button click event
-  document.querySelector('.nav--header .button--nav').onclick = () => {
-    console.log('test')
-    if (navList.style.maxHeight == '0px') {
-      navList.style.maxHeight = `${navHeight}px`
-    } else {
-      navList.style.maxHeight = '0px'
-    }
-  }
 </script>

--- a/_includes/nav-header.html
+++ b/_includes/nav-header.html
@@ -26,29 +26,38 @@
 </template>
 
 <script type="text/javascript">
+  // Append button to nav
+  const buttonTemplate = document.querySelector('#buttontoggle')
+  document.querySelector('.nav')
+    .appendChild(document.importNode(buttonTemplate.content, true))
 
-const nav = document.querySelector('.nav')
-const buttonTemplate = document.querySelector('#buttontoggle')
-const button = document.importNode(buttonTemplate.content, true)
-nav.appendChild(button)
+  // Get initial height of nav list
+  const navList = document.querySelector('.list--nav')
+  const navHeight = navList.clientHeight
 
-const applyToggle = (list, button, breakpoint) => {
-  const navList = document.querySelector(list)
-  if (document.body.clientWidth < breakpoint) {
-    const navHeight = navList.clientHeight
-    const navButton = document.querySelector(button)
-    navList.style.maxHeight = '0px'
-
-    navButton.onclick = () => {
-      if (navList.style.maxHeight == '0px') {
-        navList.style.maxHeight = `${navHeight}px`
-      } else {
-        navList.style.maxHeight = '0px'
-      }
+  // Initially collapse nav
+  const collapseNav = () => {
+    if (document.body.clientWidth < 640) {
+      navList.style.maxHeight = '0px'
+    } else {
+      navList.removeAttribute('style')
     }
   }
-}
 
-applyToggle('.list--nav', '.button', 640)
+  collapseNav()
 
+  // Check on resize if to collapse nav
+  window.addEventListener('resize', () => {
+    collapseNav()
+  })
+
+  // Apply toggle on button click event
+  document.querySelector('.nav--header .button--nav').onclick = () => {
+    console.log('test')
+    if (navList.style.maxHeight == '0px') {
+      navList.style.maxHeight = `${navHeight}px`
+    } else {
+      navList.style.maxHeight = '0px'
+    }
+  }
 </script>

--- a/_sass/_theme.scss
+++ b/_sass/_theme.scss
@@ -39,6 +39,8 @@ body {
   display: flex;
   flex-direction: column-reverse;
   align-items: flex-end;
+  justify-content: flex-end;
+  overflow: hidden;
 }
 
 .feature {
@@ -175,7 +177,7 @@ body {
   list-style: none;
   &--nav {
     overflow: hidden;
-    transition: .2s;
+    margin-bottom: var(--listHeight, 0);
   }
   .item--post,
   .item--result,


### PR DESCRIPTION
Check the browser size on resize and remove mobile toggle styling accordingly, fixes #123