### PR TITLE
[Fix] added missing default property for accentColour

### DIFF
--- a/_sass/_settings.scss
+++ b/_sass/_settings.scss
@@ -2,7 +2,7 @@
 $backgroundColour: #ffffff !default;
 $codeBackgroundColour: #fafafa !default;
 $featureBackgroundColour: #f9fafa !default;
-$accentColour: #05bf85;
+$accentColour: #05bf85 !default;
 
 // Text colours
 $headingColour: #242e2b !default;


### PR DESCRIPTION
As discussed in #127, the `!default` property for `!accentColour` was missed by accident. This pull request fixes the issue.