### PR TITLE
[FIX] Replace layout: none with layout: null in assets

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 ---
 permalink: "manifest.json"
-layout: none
+layout: null
 ---
 {
   "lang": "{{ site.lang | default: "en-US" }}",

--- a/assets/scripts/sw.js
+++ b/assets/scripts/sw.js
@@ -1,6 +1,6 @@
 ---
 permalink: "/sw.js"
-layout: none
+layout: null
 ---
 const version = '{{ site.time | date: '%Y%m%d%H%M%S' }}';
 const cacheName = `static::${version}`;


### PR DESCRIPTION
layout:none gives a warning in the log of jekyll serve. The correct way
is layout: null. Fixed in manifest.json and sw.js

Fixes #141 
