### PR TITLE
[Fix] Broken Posts in Github-Pages Project Repo

### DIFF
--- a/assets/scripts/sw.js
+++ b/assets/scripts/sw.js
@@ -10,7 +10,7 @@ const cacheName = `static::${version}`;
 const buildContentBlob = () => {
   return [
     {%- for post in site.posts limit: 10 -%}
-      "{{ post.url }}",
+      "{{ site.baseurl }}{{ post.url }}",
     {%- endfor -%}
     {%- for page in site.pages -%}
       {%- unless page.url contains 'sw.js' or page.url contains '404.html' -%}


### PR DESCRIPTION
Fixes:  #152 

add baseurl to post url to fix broken links in github-pages project repos with a non-empty baseurl set in '_config.py'
