### PR TITLE
[Feature] Added support for custom Formspree endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Example usage: `{% include site-form.html %}`
 Available options:
 - `netlify_form=true`: Set whether you would like to use Netlify Forms, otherwise the form will default to Formspree
 - `name`: Give the form a name, by default the form is called "Contact". The name will be reflected when form submissions come through in Netlify or in your email client. The name is also used in the label and input elements for accessibility
+- `endpoint`: To use if your Formspree form has an endpoint different from your email address. If ommited, the email address will be used as endpoint
 
 
 Use the `email` option in the `/_config.yml` to change to the desired email.

--- a/_includes/site-form.html
+++ b/_includes/site-form.html
@@ -12,6 +12,14 @@
   {% assign thanks_url = "/thanks/" %}
 {% endif %}
 
+{% if include.endpoint %}
+  {% assign endpoint = include.endpoint %}
+  {% assign endpoint_type = "id" %}
+{% else %}
+  {% assign endpoint = site:email | split: "" | reverse | join: "" %}
+  {% assign endpoint_type = "email" %}
+{% endif %}
+
 <form class="form  form--{{ name_id }}" method="post" name="{{ name }}" action="{{ thanks_url }}"
   {% if include.netlify_form %}
     netlify-honeypot="bot-field"
@@ -44,10 +52,16 @@
 </form>
 {% unless include.netlify_form %}
   <script>
-    var email = "{{ site.email | split: "" | reverse | join: "" }}";
-    var unraveledEmail = email.split("").reverse().join("");
+    var endpoint = "{{ endpoint }}";
+    var endpointType = "{{ endpoint_type }}";
+
+    if (endpointType === "email") {
+      var unraveledEmail = endpoint.split("").reverse().join("");
+      endpoint = unraveledEmail;
+    }
+
     var form = document.querySelector(".form--{{ name_id }}");
-      form.setAttribute("action", "https://formspree.io/" + unraveledEmail);
+      form.setAttribute("action", "https://formspree.io/" + endpoint);
   </script>
   <noscript>Please enable JavaScript to use the form.</noscript>
 {% endunless %}

--- a/_includes/site-form.html
+++ b/_includes/site-form.html
@@ -14,10 +14,8 @@
 
 {% if include.endpoint %}
   {% assign endpoint = include.endpoint %}
-  {% assign endpoint_type = "id" %}
 {% else %}
-  {% assign endpoint = site:email | split: "" | reverse | join: "" %}
-  {% assign endpoint_type = "email" %}
+  {% assign endpoint = site:email %}
 {% endif %}
 
 <form class="form  form--{{ name_id }}" method="post" name="{{ name }}" action="{{ thanks_url }}"
@@ -52,14 +50,8 @@
 </form>
 {% unless include.netlify_form %}
   <script>
-    var endpoint = "{{ endpoint }}";
-    var endpointType = "{{ endpoint_type }}";
-
-    if (endpointType === "email") {
-      var unraveledEmail = endpoint.split("").reverse().join("");
-      endpoint = unraveledEmail;
-    }
-
+    var endpoint = "{{ endpoint | split: "" | reverse | join: "" }}";
+    var unraveledEndpoint = endpoint.split("").reverse().join("");
     var form = document.querySelector(".form--{{ name_id }}");
       form.setAttribute("action", "https://formspree.io/" + endpoint);
   </script>

--- a/_includes/site-form.html
+++ b/_includes/site-form.html
@@ -53,7 +53,7 @@
     var endpoint = "{{ endpoint | split: "" | reverse | join: "" }}";
     var unraveledEndpoint = endpoint.split("").reverse().join("");
     var form = document.querySelector(".form--{{ name_id }}");
-      form.setAttribute("action", "https://formspree.io/" + endpoint);
+      form.setAttribute("action", "https://formspree.io/" + unraveledEndpoint);
   </script>
   <noscript>Please enable JavaScript to use the form.</noscript>
 {% endunless %}


### PR DESCRIPTION
Added a setting to allow optional usage of custom Formspree endpoints, rather than using the email address itself as endpoint, which exposes it to the public as part of the POST request.

This also makes it possible to have multiple forms delivering to different addresses.