### PR TITLE
[Enhancement] Uses the value in "feature_image" as the default OpenGraph image, if "image" was not stated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,7 @@ defaults:
     scope:
       path: ""
     values:
-      image: "/assets/default-social-image.png" # Default image for sharing
+      image: "/assets/default-social-image.png" # Default image for sharing. Falls back to the value in feature_image if not stated
   -
     scope:
       path: ""

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,12 @@
       {% seo %}
     {% endif %}
 
+    {% unless page.image %}
+      {% if page.feature_image %}
+        <meta property="og:image" content="{{ page.feature_image }}" />
+      {% endif %}
+    {% endunless %}
+
     <link rel="manifest" href="{{ "/manifest.json" | relative_url }}">
     <meta name="theme-color" content="{{ site.manifest.theme_color | default: '#242e2b' }}"/>
 


### PR DESCRIPTION
This update makes the theme take the value in `feature_image` as the default OpenGraph image, unless it's overridden in the front matter by the `image` variable, either locally or globally.

Currently, the user has to explicitly state an OpenGraph image with the `image` variable, and the theme will not show any if not, even if the page has a featured image.
