### PR TITLE
[Enhancement] Removes deprecated keyCode & keypress usage in search

### DIFF
--- a/_includes/site-search.html
+++ b/_includes/site-search.html
@@ -49,8 +49,8 @@
 
   field.addEventListener('keyup', displayResults);
 
-  field.addEventListener('keypress', function(event) {
-    if (event.keyCode == 13) {
+  field.addEventListener('keydown', function(event) {
+    if (event.key === 'Enter') {
       event.preventDefault();
     }
   });


### PR DESCRIPTION
On the search page there's usage of some keyboard events that are now deprecated and could be removed from future browsers.

- `keyCode` is deprecated in favour of code & key. We use key as we care about the value of the key rather than it's physical position. (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)

- `keypress` is a deprecated event in favour of keydown which represents the same thing but isn't deprecated. (https://developer.mozilla.org/en-US/docs/Web/API/Document/keypress_event)

The javascript is pretty much the same as before so this should be ok for people to port into their themes that used this as a boilerplate.