### PR TITLE
[Fix] Add meta charset utf8 to default html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
 
   <head>
     <!-- General meta -->
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% if page.indexing == false %}


### PR DESCRIPTION
I had an issue with displaying nordic special characters on my alembic
site. Turns out some browsers don't default to utf8. utf8 seems like a
sane default to me, so I decided to add it and everything works great.

Fixes: #151 