### PR TITLE
[Enhancement] Load custom fonts async

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Site settings](#site-settings)
   - [Site performance settings](#site-performance-settings)
   - [Site navigation](#site-navigation)
+  - [Custom fonts](#custom-fonts)
 - [Using includes](#using-includes)
 - [Page layouts](#page-layouts)
 - [Page and Post options](#page-and-post-options)
@@ -59,16 +60,16 @@ Here are a few examples of Alembic out in the wild being used in a variety of wa
 
 To give you a running start I've put together some starter kits that you can download, fork or even deploy immediately:
 
-- Vanilla Jekyll starter kit:  
+- Vanilla Jekyll starter kit:
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daviddarnes/alembic-kit)
-- Forestry starter kit:  
-  [![Deploy to Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=daviddarnes/alembic-forestry-kit&engine=jekyll)  
+- Forestry starter kit:
+  [![Deploy to Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=daviddarnes/alembic-forestry-kit&engine=jekyll)
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daviddarnes/alembic-forestry-kit)
-- Netlify CMS starter kit:  
+- Netlify CMS starter kit:
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daviddarnes/alembic-netlifycms-kit&stack=cms)
 
 - GitHub Pages with remote theme kit - **[Download kit](https://github.com/daviddarnes/alembic-kit/archive/remote-theme.zip)**
-- Stackbit starter kit:  
+- Stackbit starter kit:
   [![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/daviddarnes/alembic-stackbit-kit)
 
 ### As a Jekyll theme
@@ -146,6 +147,17 @@ There are a total of 4 different navigation types:
 All navigations can be edited using the `_config.yml` file. To see example usage either look for the `Site navigation` comment within the `/_config.yml` file or see [the nav-share.html include](#nav-sharehtml).
 
 If there are no items for the `navigation_header` or `navigation_footer`, they will fallback to a list of pages within the site. The `social_navigation` properties should either be one that is already in the list (so `Twitter` or `Facebook`) or a regular `link`, this is so an icon can be set for the link.
+
+### Custom fonts
+
+Alembic comes with custom fonts served from Google fonts. By default it requests Merriweather but this can be any font from any provider assuming it supports requesting fonts in the same manner and does not require javascript.
+
+This can be configured under the `custom_fonts` key.
+
+- `urls`: The urls supplied to you from your font provider (eg https://fonts.googleapis.com/css2?family=Merriweather). For best performance try to use as few urls as possible
+- `preconnect`: (optional) If your font provider serves the font files from another domain it can be useful to make a connection to that domain in advance. For example google load the font files from fonts.gstatic.com. This can be omitted if not required
+
+If you want to customise this further you can find the include for custom fonts in `_includes/site-custom-fonts.html`.
 
 ## Using includes
 

--- a/_config.yml
+++ b/_config.yml
@@ -147,3 +147,13 @@ sharing_links: # Appear at the bottom of single blog posts, add as desired. The 
   Twitter: "#0d94e7"
   facebook: "#3B5998"
   Email: true
+
+# Load custom fonts from fonts.google.com etc
+#
+# TIP: Try to keep the number of urls as low to reduce the performance cost
+#      If multiple fonts can be requested in a single url opt for this
+custom_fonts:
+  preconnect:
+    - https://fonts.gstatic.com
+  urls:
+    - https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap

--- a/_config.yml
+++ b/_config.yml
@@ -152,8 +152,8 @@ sharing_links: # Appear at the bottom of single blog posts, add as desired. The 
 #
 # TIP: Try to keep the number of urls as low to reduce the performance cost
 #      If multiple fonts can be requested in a single url opt for this
-custom_fonts:
-  preconnect:
+fonts:
+  preconnect_urls:
     - https://fonts.gstatic.com
-  urls:
+  font_urls:
     - https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap

--- a/_includes/site-custom-fonts.html
+++ b/_includes/site-custom-fonts.html
@@ -1,0 +1,6 @@
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" />
+<link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+<noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" rel="stylesheet" />
+</noscript>

--- a/_includes/site-custom-fonts.html
+++ b/_includes/site-custom-fonts.html
@@ -1,6 +1,11 @@
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" />
-<link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
-<noscript>
-    <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap" rel="stylesheet" />
-</noscript>
+{% if site.custom_fonts.urls %}
+    {% for font in site.custom_fonts.urls %}
+        <link rel="preload" as="style" href="{{ font }}" />
+        <link href="{{ font }}" rel="stylesheet" media="print" onload="this.media='all'" />
+    {% endfor %}
+    <noscript>
+        {% for font in site.custom_fonts.urls %}
+            <link href="{{ font }}" rel="stylesheet" />
+        {% endfor %}
+    </noscript>
+{% endif %}

--- a/_includes/site-fonts.html
+++ b/_includes/site-fonts.html
@@ -1,10 +1,10 @@
-{% if site.custom_fonts.urls %}
-    {% for font in site.custom_fonts.urls %}
+{% if site.fonts.font_urls %}
+    {% for font in site.fonts.font_urls %}
         <link rel="preload" as="style" href="{{ font }}" />
         <link href="{{ font }}" rel="stylesheet" media="print" onload="this.media='all'" />
     {% endfor %}
     <noscript>
-        {% for font in site.custom_fonts.urls %}
+        {% for font in site.fonts.font_urls %}
             <link href="{{ font }}" rel="stylesheet" />
         {% endfor %}
     </noscript>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,11 @@
     {% else %}
       {% seo %}
     {% endif %}
+    {% if site.custom_fonts.preconnect %}
+      {% for preconnect in site.custom_fonts.preconnect %}
+        <link rel="preconnect" href="{{ preconnect }}" crossorigin />
+      {% endfor %}
+    {% endif %}
 
     <link rel="manifest" href="{{ "/manifest.json" | relative_url }}">
     <meta name="theme-color" content="{{ site.manifest.theme_color | default: '#242e2b' }}"/>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,8 @@
 
     {% if site.google_analytics %}{% include site-analytics.html %}{% endif %}
 
+    {% include site-custom-fonts.html %}
+
     {% include site-before-start.html %}
   </head>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,9 +20,9 @@
     {% else %}
       {% seo %}
     {% endif %}
-    {% if site.custom_fonts.preconnect %}
-      {% for preconnect in site.custom_fonts.preconnect %}
-        <link rel="preconnect" href="{{ preconnect }}" crossorigin />
+    {% if site.fonts.preconnect_urls %}
+      {% for url in site.fonts.preconnect_urls %}
+        <link rel="preconnect" href="{{ url }}" crossorigin />
       {% endfor %}
     {% endif %}
 
@@ -39,7 +39,7 @@
 
     {% if site.google_analytics %}{% include site-analytics.html %}{% endif %}
 
-    {% include site-custom-fonts.html %}
+    {% include site-fonts.html %}
 
     {% include site-before-start.html %}
   </head>

--- a/_sass/_settings.scss
+++ b/_sass/_settings.scss
@@ -35,5 +35,4 @@ $monospacetype: (
   cap-height: 0.68
 ) !default;
 
-// Font import, if you're using a non-standard web font
-@import url("https://fonts.googleapis.com/css?family=Merriweather:400,700");
+// TIP: Add custom fonts to _includes/site-custom-fonts.html

--- a/_sass/_settings.scss
+++ b/_sass/_settings.scss
@@ -35,4 +35,4 @@ $monospacetype: (
   cap-height: 0.68
 ) !default;
 
-// TIP: Add custom fonts to _includes/site-custom-fonts.html
+// TIP: Load custom fonts in _config.yaml


### PR DESCRIPTION
Rather than using a css import for the font use async loading using the print media hack + a few other bits and bobs. For more info check out https://csswizardry.com/2020/05/the-fastest-google-fonts/

Also uses font-display: swap so users are able to read the text even though the font hasn't downloaded yet

Finally uses the latest google font api for including the fonts.

I added a TIP comment to _settings.scss so that people customizing this theme know where to go to register their fonts now but let me know if there needs to be any more docs 🙂 
