### PR TITLE
[Fix] Service worker and favicon paths to include baseurl

### DIFF
--- a/_includes/site-favicons.html
+++ b/_includes/site-favicons.html
@@ -1,7 +1,7 @@
 {% if site.favicons %}
   {% for icon in site.favicons %}
-    <link rel="icon" type="image/png" href="{{ icon[1] }}" sizes="{{ icon[0] }}x{{ icon[0] }}">
-    <link rel="apple-touch-icon" sizes="{{ icon[0] }}x{{ icon[0] }}" href="{{ icon[1] }}">
+    <link rel="icon" type="image/png" href="{{ icon[1] | relative_url }}" sizes="{{ icon[0] }}x{{ icon[0] }}">
+    <link rel="apple-touch-icon" sizes="{{ icon[0] }}x{{ icon[0] }}" href="{{ icon[1] | relative_url }}">
   {% endfor %}
 {% endif %}
-<link rel="shortcut icon" href="{{ site.avatarurl + '?s=32' | default: site.logo }}">
+<link rel="shortcut icon" href="{{ site.avatarurl + '?s=32' | default: site.logo | relative_url }}">

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -13,7 +13,7 @@ sitemap: false
     "icons": [
       {% for icon in site.favicons %}
         {
-          "src": "{{ icon[1] }}",
+          "src": "{{ icon[1] | relative_url }}",
           "sizes": "{{ icon[0] }}x{{ icon[0] }}"
         }{% if forloop.last != true %},{% endif %}
       {% endfor %}

--- a/assets/scripts/sw.js
+++ b/assets/scripts/sw.js
@@ -10,14 +10,14 @@ const cacheName = `static::${version}`;
 const buildContentBlob = () => {
   return [
     {%- for post in site.posts limit: 10 -%}
-      "{{ site.baseurl }}{{ post.url }}",
+      "{{ post.url | relative_url }}",
     {%- endfor -%}
     {%- for page in site.pages -%}
       {%- unless page.url contains 'sw.js' or page.url contains '404.html' -%}
-        "{{ page.url }}",
+        "{{ page.url | relative_url }}",
       {%- endunless -%}
     {%- endfor -%}
-      "{{ site.logo }}", "/assets/default-offline-image.png", "/assets/scripts/fetch.js"
+      "{{ site.logo | relative_url }}", "{{ site.baseurl }}/assets/default-offline-image.png", "{{ site.baseurl }}/assets/scripts/fetch.js"
   ]
 }
 
@@ -75,7 +75,7 @@ self.addEventListener("fetch", event => {
 
   if (request.url.match(/\.(jpe?g|png|gif|svg)$/)) {
     // If url requested is an image and isn't cached, return default offline image
-    offlineAsset = "/assets/default-offline-image.png";
+    offlineAsset = "{{ site.baseurl }}/assets/default-offline-image.png";
   }
 
   // For all urls request image from network, then fallback to cache, then fallback to offline page


### PR DESCRIPTION
The service worker code and site favicon code wasn't including the `baseurl` when it was set, this change fixes that using the `relative_url` filter.

Fixes #162 