### PR TITLE
[Enhancement] Make manifest short_name configurable via site.short_name

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -6,19 +6,19 @@ sitemap: false
 {
   "lang": "{{ site.lang | default: "en-US" }}",
   "name": "{{ site.title }}",
-  "short_name": "{{ site.title | replace: ' ', '' }}",
+  "short_name": "{{ site.short_name | default: site.title | replace: ' ', '' }}",
   "theme_color": "{{ site.manifest.theme_color | default: '#24292e' }}",
   "background_color": "{{ site.manifest.background_color | default: '#ffffff' }}",
-  {% if site.favicons %}
+  {% if site.favicons -%}
     "icons": [
-      {% for icon in site.favicons %}
-        {
-          "src": "{{ icon[1] | relative_url }}",
-          "sizes": "{{ icon[0] }}x{{ icon[0] }}"
-        }{% if forloop.last != true %},{% endif %}
+      {% for icon in site.favicons -%}
+      {
+        "src": "{{ icon[1] | relative_url }}",
+        "sizes": "{{ icon[0] }}x{{ icon[0] }}"
+      }{% if forloop.last != true %},{% endif %}
       {% endfor %}
     ],
-  {%- endif -%}
+  {% endif -%}
   "start_url": "/",
   "display": "standalone"
 }


### PR DESCRIPTION
This make it possible configure `short_name` field in the generated `manifest.json`. 

Documentation to the short_name specification can be found in:
* https://developer.mozilla.org/en-US/docs/Web/Manifest/short_name
* https://w3c.github.io/manifest/#short_name-member

Defaults to use site.title with previous filters (so this is backward compatible).

I've also tweaked how the whitespace is generated to have a more well formatted json file than before.