### PR TITLE
[Fix] Add documentation for short_name key, clean up date_format key and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ Here are a few examples of Alembic out in the wild being used in a variety of wa
 
 To give you a running start I've put together some starter kits that you can download, fork or even deploy immediately:
 
-- Vanilla Jekyll starter kit:  
+- Vanilla Jekyll starter kit:
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daviddarnes/alembic-kit)
-- Forestry starter kit:  
-  [![Deploy to Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=daviddarnes/alembic-forestry-kit&engine=jekyll)  
+- Forestry starter kit:
+  [![Deploy to Forestry](https://assets.forestry.io/import-to-forestry.svg)](https://app.forestry.io/quick-start?repo=daviddarnes/alembic-forestry-kit&engine=jekyll)
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daviddarnes/alembic-forestry-kit)
-- Netlify CMS starter kit:  
+- Netlify CMS starter kit:
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/daviddarnes/alembic-netlifycms-kit&stack=cms)
 
 - GitHub Pages with remote theme kit - **[Download kit](https://github.com/daviddarnes/alembic-kit/archive/remote-theme.zip)**
-- Stackbit starter kit:  
+- Stackbit starter kit:
   [![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/daviddarnes/alembic-stackbit-kit)
 
 ### As a Jekyll theme
@@ -122,8 +122,9 @@ You'll need to change the `description`, `title` and `url` to match with the pro
 
 Google Analytics can be enabled via the site configuration too. Add your tracking ID to the `/_config.yml` file in the following method: `google_analytics: 'UA-XXXXXXXX-1'`. By default all IPs of site visitors are anonymous to maintain a level of privacy for the audience. If you wish to turn this off set the `google_analytics_anonymize_ip` key to `false`.
 
-Date format can be customised in the `/_config.yml` with the option `date_format` (please refer to Liquid date filters documentation for learning about formatting possibilities):
-`date_format: "%-d %B %Y" # NOTE: only placeholder formatting is supported (do not try to use ordinal dates introduced in Jekyll 3.8)`
+Date format can be customised in the `/_config.yml` with the option `date_format` (please refer to Liquid date filters documentation for learning about formatting possibilities). Only placeholder formatting is supported, do not try to use ordinal dates introduced in Jekyll 3.8.
+
+The `short_name` option within `/_config.yml` is to add a custom name to the site's web application counterpart. When the website is added to a device this name will appear alonside the app icon. The short name will default to the site title if this isn't set.
 
 ### Site performance settings
 

--- a/_config.yml
+++ b/_config.yml
@@ -101,9 +101,11 @@ baseurl: ""
 repo: "https://github.com/daviddarnes/alembic"
 email: "me@daviddarnes.com"
 # disqus: "alembic-1" # Blog post comments, uncomment the option and set the site ID from your Disqus account
-# google_analytics: ''
-# google_analytics_anonymize_ip: ''
+# date_format: "%-d %B %Y" # Blog post date formatting using placeholder formatting
+# google_analytics: ""
+# google_analytics_anonymize_ip: ""
 # service_worker: false # Will turn off the service worker if set to false
+# short_name: "Al" # The web application short name, defaults to the site title
 css_inline: true # Will insert all styles into a single <style> block in the <head> element and remove the style <link> reference
 
 # 8. Site favicons & manifest icons

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -6,19 +6,19 @@ sitemap: false
 {
   "lang": "{{ site.lang | default: "en-US" }}",
   "name": "{{ site.title }}",
-  "short_name": "{{ site.title | replace: ' ', '' }}",
+  "short_name": "{{ site.short_name | default: site.title | replace: ' ', '' }}",
   "theme_color": "{{ site.manifest.theme_color | default: '#24292e' }}",
   "background_color": "{{ site.manifest.background_color | default: '#ffffff' }}",
-  {% if site.favicons %}
+  {% if site.favicons -%}
     "icons": [
-      {% for icon in site.favicons %}
-        {
-          "src": "{{ icon[1] | relative_url }}",
-          "sizes": "{{ icon[0] }}x{{ icon[0] }}"
-        }{% if forloop.last != true %},{% endif %}
+      {% for icon in site.favicons -%}
+      {
+        "src": "{{ icon[1] | relative_url }}",
+        "sizes": "{{ icon[0] }}x{{ icon[0] }}"
+      }{% if forloop.last != true %},{% endif %}
       {% endfor %}
     ],
-  {%- endif -%}
+  {% endif -%}
   "start_url": "/",
   "display": "standalone"
 }


### PR DESCRIPTION
- Clean up readme file
- Add `short_name` key documentation
- Add `date_format` to the main config file as a commented example
- Adjust `date_format` documentation