### PR TITLE
[Enhancement] Bump jekyll-seo-tag to 2.7.1 so that we can use `tagline`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,6 @@ exclude:
 plugins:
 - jekyll-sitemap
 - jekyll-mentions
-- jekyll-paginate
 - jekyll-seo-tag
 - jekyll-redirect-from
 - jekyll-feed
@@ -35,8 +34,6 @@ plugins:
 - jemoji
 
 # 3. Gem settings
-paginate: 2 # jekyll-paginate > items per page
-paginate_path: blog/page:num # jekyll-paginate > blog page
 jekyll-mentions: https://twitter.com # jekyll-mentions > service used when @replying
 twitter:
   username: DavidDarnes # jekyll-seo-tag > Owners twitter username

--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ exclude:
 plugins:
 - jekyll-sitemap
 - jekyll-mentions
+- jekyll-paginate
 - jekyll-seo-tag
 - jekyll-redirect-from
 - jekyll-feed
@@ -34,6 +35,8 @@ plugins:
 - jemoji
 
 # 3. Gem settings
+paginate: 2 # jekyll-paginate > items per page
+paginate_path: blog/page:num # jekyll-paginate > blog page
 jekyll-mentions: https://twitter.com # jekyll-mentions > service used when @replying
 twitter:
   username: DavidDarnes # jekyll-seo-tag > Owners twitter username

--- a/alembic-jekyll-theme.gemspec
+++ b/alembic-jekyll-theme.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4.0"
   spec.add_runtime_dependency "jekyll-mentions", "~> 1.6.0"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1.0"
-  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.6.1"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.7.1"
   spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.16"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.15"
   spec.add_runtime_dependency "jekyll-commonmark", "~> 1.3.1"


### PR DESCRIPTION
Jekyll SEO Tags support using the `tagline` attribute to build the `<title>` HTML tag since [v2.7.0](https://github.com/jekyll/jekyll-seo-tag/releases/tag/v2.7.0). Since I need that in a project, and there doesn't seem to be any breaking change, I figured I might as well sugggest a fix ;)
